### PR TITLE
update to use neat v0.25.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/dracory/blindindexstore
 go 1.26.3
 
 require (
-	github.com/dracory/neat v0.23.0
+	github.com/dracory/neat v0.25.0
 	modernc.org/sqlite v1.52.0
 )
 

--- a/go.sum
+++ b/go.sum
@@ -6,8 +6,8 @@ github.com/coder/websocket v1.8.14 h1:9L0p0iKiNOibykf283eHkKUHHrpG7f65OE3BhhO7v9
 github.com/coder/websocket v1.8.14/go.mod h1:NX3SzP+inril6yawo5CQXx8+fk145lPDC6pumgx0mVg=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/dracory/neat v0.23.0 h1:ogr9kH77ZzyfjJXh29HjWSsCfg3jt9d3kM4mFHlTjiI=
-github.com/dracory/neat v0.23.0/go.mod h1:TpQLRBHkhLZpPqDpbOnAA2TMevSA4BlmgjA133hLEyA=
+github.com/dracory/neat v0.25.0 h1:W/pUxpRI1zoFTPTgsMmIKJx9RPiVoUT1Q8R6VjWCLzw=
+github.com/dracory/neat v0.25.0/go.mod h1:TpQLRBHkhLZpPqDpbOnAA2TMevSA4BlmgjA133hLEyA=
 github.com/dromara/carbon/v2 v2.6.16 h1:AbxrnW1kJhR3KHdS8G96NFmxDwPFyre+t+xSiJIUD1I=
 github.com/dromara/carbon/v2 v2.6.16/go.mod h1:NGo3reeV5vhWCYWcSqbJRZm46MEwyfYI5EJRdVFoLJo=
 github.com/dustin/go-humanize v1.0.1 h1:GzkhY7T5VNhEkwH0PVJgjz+fX1rhBrR7pRT3mDkpeCY=


### PR DESCRIPTION
This PR updates the `github.com/dracory/neat` dependency from v0.23.0 to v0.25.0. 
I have verified that the update is correctly reflected in `go.mod` and that all existing tests pass with the new version.

---
*PR created automatically by Jules for task [15151075981533100440](https://jules.google.com/task/15151075981533100440) started by @lesichkovm*